### PR TITLE
Initial AerospikeCacheManger implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
 
 		<dependency>
 			<groupId>org.springframework</groupId>
+			<artifactId>spring-context-support</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework</groupId>
 			<artifactId>spring-tx</artifactId>
 		</dependency>
 

--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
@@ -16,13 +16,15 @@ import com.aerospike.client.policy.WritePolicy;
  * 
  * @author Venil Noronha
  */
-public class AerospikeCache implements Cache{
+public class AerospikeCache implements Cache {
+
 	private static final String VALUE = "value";
-	private final AerospikeClient client;
-	private String namespace;
-	private String set;
-	private WritePolicy createOnly;
-	
+
+	protected AerospikeClient client;
+	protected String namespace;
+	protected String set;
+	protected WritePolicy createOnly;
+
 	public AerospikeCache(String namespace, String set, AerospikeClient client,
 			long expiration){
 		this.client = client;
@@ -32,7 +34,7 @@ public class AerospikeCache implements Cache{
 		this.createOnly.recordExistsAction = RecordExistsAction.CREATE_ONLY;
 	}
 	
-	private Key getKey(Object key){
+	protected Key getKey(Object key){
 		return new Key(namespace, set, key.toString());
 	}
 
@@ -77,7 +79,6 @@ public class AerospikeCache implements Cache{
 	@Override
 	public void put(Object key, Object value) {
 		client.put(null, getKey(key), new Bin(VALUE, value));
-		
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCache.java
@@ -12,6 +12,10 @@ import com.aerospike.client.Record;
 import com.aerospike.client.policy.RecordExistsAction;
 import com.aerospike.client.policy.WritePolicy;
 
+/**
+ * 
+ * @author Venil Noronha
+ */
 public class AerospikeCache implements Cache{
 	private static final String VALUE = "value";
 	private final AerospikeClient client;
@@ -31,8 +35,9 @@ public class AerospikeCache implements Cache{
 	private Key getKey(Object key){
 		return new Key(namespace, set, key.toString());
 	}
-	private ValueWrapper toWrapper(Object value) {
-		return (value != null ? new SimpleValueWrapper(value) : null);
+
+	private ValueWrapper toWrapper(Record record) {
+		return (record != null ? new SimpleValueWrapper(record.getValue(VALUE)) : null);
 	}
 	
 	@Override
@@ -50,7 +55,7 @@ public class AerospikeCache implements Cache{
 	@Override
 	public ValueWrapper get(Object key) {
 		Record record =  client.get(null, getKey(key));
-		ValueWrapper vr = toWrapper(record.getValue(VALUE));
+		ValueWrapper vr = toWrapper(record);
 		return vr;
 	}
 
@@ -78,7 +83,7 @@ public class AerospikeCache implements Cache{
 	@Override
 	public ValueWrapper putIfAbsent(Object key, Object value) {
 		Record record = client.operate(this.createOnly, getKey(key), Operation.put(new Bin(VALUE, value)), Operation.get(VALUE));
-		return toWrapper(record.getValue(VALUE));
+		return toWrapper(record);
 	}
 
 }

--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
@@ -1,0 +1,98 @@
+package org.springframework.data.aerospike.cache;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.transaction.AbstractTransactionSupportingCacheManager;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+import org.springframework.util.Assert;
+
+import com.aerospike.client.AerospikeClient;
+
+/**
+ * 
+ * @author Venil Noronha
+ */
+public class AerospikeCacheManager extends AbstractTransactionSupportingCacheManager {
+
+	protected static final String DEFAULT_SET_NAME = "aerospike";
+	
+	private AerospikeClient aerospikeClient;
+	private String setName;
+	private Set<String> configuredCacheNames;
+
+	public AerospikeCacheManager(AerospikeClient aerospikeClient) {
+		this(aerospikeClient, Collections.<String>emptyList());
+	}
+
+	public AerospikeCacheManager(AerospikeClient aerospikeClient,
+			Collection<String> cacheNames) {
+		this(aerospikeClient, cacheNames, DEFAULT_SET_NAME);
+	}
+
+	public AerospikeCacheManager(AerospikeClient aerospikeClient,
+			Collection<String> cacheNames, String setName) {
+		Assert.notNull(aerospikeClient, "AerospikeClient must not be null");
+		Assert.notNull(cacheNames, "Cache names must not be null");
+		Assert.notNull(setName, "Set name must not be null");
+		this.aerospikeClient = aerospikeClient;
+		this.setName = setName;
+		this.configuredCacheNames = new LinkedHashSet<String>(cacheNames);
+	}
+
+	@Override
+	protected Collection<? extends Cache> loadCaches() {
+		List<AerospikeCache> caches = new ArrayList<AerospikeCache>();
+		for (String cacheName : configuredCacheNames) {
+			caches.add(createCache(cacheName));
+		}
+		return caches;
+	}
+
+	@Override
+	protected Cache getMissingCache(String cacheName) {
+		return createCache(cacheName);
+	}
+	
+	protected AerospikeCache createCache(String cacheName) {
+		return new AerospikeCache(cacheName, setName, aerospikeClient, -1);
+	}
+	
+	@Override
+	public Cache getCache(String name) {
+		Cache cache = lookupAerospikeCache(name);
+		if (cache != null) {
+			return cache;
+		}
+		else {
+			Cache missingCache = getMissingCache(name);
+			if (missingCache != null) {
+				addCache(missingCache);
+				return lookupAerospikeCache(name);  // may be decorated
+			}
+			return null;
+		}
+	}
+
+	protected Cache lookupAerospikeCache(String name) {
+		return lookupCache(name + ":" + setName);
+	}
+
+	@Override
+	protected Cache decorateCache(Cache cache) {
+		if (isCacheAlreadyDecorated(cache)) {
+			return cache;
+		}
+		return super.decorateCache(cache);
+	}
+
+	protected boolean isCacheAlreadyDecorated(Cache cache) {
+		return isTransactionAware() && cache instanceof TransactionAwareCacheDecorator;
+	}
+
+}

--- a/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
+++ b/src/main/java/org/springframework/data/aerospike/cache/AerospikeCacheManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.data.aerospike.cache;
 
 import java.util.ArrayList;
@@ -8,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.transaction.AbstractTransactionSupportingCacheManager;
 import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
 import org.springframework.util.Assert;
@@ -15,26 +32,65 @@ import org.springframework.util.Assert;
 import com.aerospike.client.AerospikeClient;
 
 /**
+ * {@link CacheManager} implementation for Aerospike. By default {@link AerospikeCache}s
+ * will be lazily initialized for each {@link #getCache(String)} request unless a set of
+ * predefined cache names is provided. <br>
+ * <br>
+ * Setting {@link #setTransactionAware(boolean)} to <code>true</code> will force Caches to
+ * be decorated as {@link TransactionAwareCacheDecorator} so values will only be written
+ * to the cache after successful commit of surrounding transaction.
  * 
  * @author Venil Noronha
  */
 public class AerospikeCacheManager extends AbstractTransactionSupportingCacheManager {
 
 	protected static final String DEFAULT_SET_NAME = "aerospike";
-	
+
 	private AerospikeClient aerospikeClient;
 	private String setName;
 	private Set<String> configuredCacheNames;
 
+	/**
+	 * Create a new {@link AerospikeCacheManager} instance with no caches and with the
+	 * set name "aerospike".
+	 * 
+	 * @param aerospikeClient the {@link AerospikeClient} instance.
+	 */
 	public AerospikeCacheManager(AerospikeClient aerospikeClient) {
 		this(aerospikeClient, Collections.<String>emptyList());
 	}
 
+	/**
+	 * Create a new {@link AerospikeCacheManager} instance with no caches and with the
+	 * specified set name.
+	 * 
+	 * @param aerospikeClient the {@link AerospikeClient} instance.
+	 * @param setName the set name.
+	 */
+	public AerospikeCacheManager(AerospikeClient aerospikeClient, String setName) {
+		this(aerospikeClient, Collections.<String>emptyList(), setName);
+	}
+
+	/**
+	 * Create a new {@link AerospikeCacheManager} instance with the specified caches and
+	 * with the set name "aerospike".
+	 * 
+	 * @param aerospikeClient the {@link AerospikeClient} instance.
+	 * @param cacheNames the default caches to create.
+	 */
 	public AerospikeCacheManager(AerospikeClient aerospikeClient,
 			Collection<String> cacheNames) {
 		this(aerospikeClient, cacheNames, DEFAULT_SET_NAME);
 	}
 
+	/**
+	 * Create a new {@link AerospikeCacheManager} instance with the specified caches and
+	 * with the specified set name.
+	 * 
+	 * @param aerospikeClient the {@link AerospikeClient} instance.
+	 * @param cacheNames the default caches to create.
+	 * @param setName the set name.
+	 */
 	public AerospikeCacheManager(AerospikeClient aerospikeClient,
 			Collection<String> cacheNames, String setName) {
 		Assert.notNull(aerospikeClient, "AerospikeClient must not be null");
@@ -58,11 +114,11 @@ public class AerospikeCacheManager extends AbstractTransactionSupportingCacheMan
 	protected Cache getMissingCache(String cacheName) {
 		return createCache(cacheName);
 	}
-	
+
 	protected AerospikeCache createCache(String cacheName) {
 		return new AerospikeCache(cacheName, setName, aerospikeClient, -1);
 	}
-	
+
 	@Override
 	public Cache getCache(String name) {
 		Cache cache = lookupAerospikeCache(name);

--- a/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheMangerTests.java
+++ b/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheMangerTests.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.data.aerospike.cache;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheMangerTests.java
+++ b/src/test/java/org/springframework/data/aerospike/cache/AerospikeCacheMangerTests.java
@@ -1,0 +1,134 @@
+package org.springframework.data.aerospike.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.transaction.TransactionAwareCacheDecorator;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Key;
+
+/**
+ * 
+ * @author Venil Noronha
+ */
+public class AerospikeCacheMangerTests {
+
+	private static AerospikeClient client;
+
+	@BeforeClass
+	public static void setUp() {
+		client = new AerospikeClient("localhost", 3000);
+	}
+	
+	@AfterClass
+	public static void tearDown() {
+		client.close();
+	}
+	
+	@Test
+	public void testMissingCache() {
+		AerospikeCacheManager manager = new AerospikeCacheManager(client);
+		manager.afterPropertiesSet();
+		Cache cache = manager.getCache("missing-cache");
+		assertNotNull("Cache instance was null", cache);
+		assertTrue("Cache was not an instance of AerospikeCache", cache instanceof AerospikeCache);
+	}
+	
+	@Test
+	public void testDefaultCache() {
+		AerospikeCacheManager manager = new AerospikeCacheManager(client,
+				Arrays.asList("default-cache"));
+		manager.afterPropertiesSet();
+		Cache cache = manager.lookupAerospikeCache("default-cache");
+		assertNotNull("Cache instance was null", cache);
+		assertTrue("Cache was not an instance of AerospikeCache", cache instanceof AerospikeCache);
+	}
+	
+	@Test
+	public void testDefaultCacheWithCustomizedSet() {
+		AerospikeCacheManager manager = new AerospikeCacheManager(client,
+				Arrays.asList("default-cache"), "custom-set");
+		manager.afterPropertiesSet();
+		Cache cache = manager.lookupAerospikeCache("default-cache");
+		assertNotNull("Cache instance was null", cache);
+		assertTrue("Cache was not an instance of AerospikeCache", cache instanceof AerospikeCache);
+	}
+	
+	@Test
+	public void testTransactionAwareCache() {
+		AerospikeCacheManager manager = new AerospikeCacheManager(client);
+		manager.setTransactionAware(true);
+		manager.afterPropertiesSet();
+		Cache cache = manager.getCache("transaction-aware-cache");
+		assertNotNull("Cache instance was null", cache);
+		assertTrue("Cache was not an instance of TransactionAwareCacheDecorator", cache instanceof TransactionAwareCacheDecorator);
+	}
+	
+	@Test
+	public void testCacheable() {
+		cleanupForTestCacheableTest();
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(CachingConfiguration.class);
+		try {
+			CachingComponent cachingComponent = ctx.getBean(CachingComponent.class);
+			cachingComponent.cachingMethod("foo");
+			cachingComponent.cachingMethod("foo");
+			assertEquals("Component didn't cache result", cachingComponent.getNoOfCalls(), 1);
+		}
+		finally {
+			ctx.close();
+			cleanupForTestCacheableTest();
+		}
+	}
+
+	private void cleanupForTestCacheableTest() {
+		client.delete(null, new Key("test", AerospikeCacheManager.DEFAULT_SET_NAME, "foo"));
+	}
+	
+	public static class CachingComponent {
+		
+		private int noOfCalls = 0;
+		
+		@Cacheable("test")
+		public String cachingMethod(String param) {
+			noOfCalls ++;
+			return "bar";
+		}
+
+		public int getNoOfCalls() {
+			return noOfCalls;
+		}
+		
+	}
+	
+	@Configuration
+	@EnableCaching
+	public static class CachingConfiguration extends CachingConfigurerSupport {
+		
+		@Bean
+		public AerospikeCacheManager cacheManager() {
+			AerospikeCacheManager cacheManager = new AerospikeCacheManager(client);
+			return cacheManager;
+		}
+		
+		@Bean
+		public CachingComponent cachingComponent() {
+			return new CachingComponent();
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
Hi,

I've created a basic `AerospikeCacheManager` implementation along with a few tests. The primary purpose of this class is to support the `Cacheable` annotation and other similar utilities. I've created a few tests to test out the `Cacheable` and `CacheEvict` annotations while being backed by `AerospikeCacheManager`.

Please review and pull. My CLA number is 149720151120072904.

Thanks,
Venil Noronha