### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>Spring Data Aerospike</name>
     <organization>
         <name>Aerospike Inc.</name>
-        <url>http://www.aerospike.com</url>
+        <url>https://www.aerospike.com</url>
     </organization>
 
  	<parent>
@@ -40,7 +40,7 @@
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 
@@ -49,9 +49,9 @@
             <id>Peter Milne</id>
             <name>Peter Milne</name>
             <email>peter@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -61,9 +61,9 @@
             <id>Michael Zhang</id>
             <name>Michael Zhang</name>
             <email>mzhang@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -73,9 +73,9 @@
             <id>Jeff Boone</id>
             <name>Jeff Boone</name>
             <email>jboone@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -85,7 +85,7 @@
             <id>Anastasiia Smirnova</id>
             <name>Anastasiia Smirnova</name>
             <email>asmirnova@playtika.com</email>
-            <url>http://www.playtika.com</url>
+            <url>https://www.playtika.com</url>
         </developer>
         <developer>
             <id>Roman Terentiev</id>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://www.aerospike.com migrated to:  
  https://www.aerospike.com ([https](https://www.aerospike.com) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.playtika.com migrated to:  
  https://www.playtika.com ([https](https://www.playtika.com) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance