### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -10,7 +10,7 @@
     <name>Spring Data Aerospike</name>
     <organization>
         <name>Aerospike Inc.</name>
-        <url>http://www.aerospike.com</url>
+        <url>https://www.aerospike.com</url>
     </organization>
 
  	<parent>
@@ -49,9 +49,9 @@
             <id>Peter Milne</id>
             <name>Peter Milne</name>
             <email>peter@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -61,9 +61,9 @@
             <id>Michael Zhang</id>
             <name>Michael Zhang</name>
             <email>mzhang@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -73,9 +73,9 @@
             <id>Jeff Boone</id>
             <name>Jeff Boone</name>
             <email>jboone@aerospike.com</email>
-            <url>http://www.aerospike.com</url>
+            <url>https://www.aerospike.com</url>
             <organization>Aerospike Inc.</organization>
-            <organizationUrl>http://www.aerospike.com</organizationUrl>
+            <organizationUrl>https://www.aerospike.com</organizationUrl>
             <roles>
                 <role>developer</role>
             </roles>
@@ -85,7 +85,7 @@
             <id>Anastasiia Smirnova</id>
             <name>Anastasiia Smirnova</name>
             <email>asmirnova@playtika.com</email>
-            <url>http://www.playtika.com</url>
+            <url>https://www.playtika.com</url>
         </developer>
         <developer>
             <id>Roman Terentiev</id>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://www.aerospike.com with 7 occurrences migrated to:  
  https://www.aerospike.com ([https](https://www.aerospike.com) result 200).
* http://www.playtika.com with 1 occurrences migrated to:  
  https://www.playtika.com ([https](https://www.playtika.com) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences